### PR TITLE
Add the Pants build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Inspired by [awesome-php](https://github.com/ziadoz/awesome-php).
 
 * [BitBake](http://www.yoctoproject.org/docs/1.6/bitbake-user-manual/bitbake-user-manual.html) - A make-like build tool for embedded Linux.
 * [buildout](http://www.buildout.org/en/latest/) - A build system for creating, assembling and deploying applications from multiple parts.
+* [Pants](https://www.pantsbuild.org/) - A fast, scalable, and flexible build system for multiple languages. Written in Python and Rust.
 * [PlatformIO](https://github.com/platformio/platformio-core) - A console tool to build code with different development platforms.
 * [pybuilder](https://github.com/pybuilder/pybuilder) - A continuous build tool written in pure Python.
 * [SCons](http://www.scons.org/) - A software construction tool.


### PR DESCRIPTION
## What is this Python project?

Pants is a flexible build system for Python, JVM, Go and other languages and environments. It focuses on build determinism and fine-grained caching to make your builds fast and reliable. It leverages existing information via code introspection to minimize boilerplate and intelligently create dependency links between parts of your codebase, so that you can build, test, and ship the things that you've changed, and not the things you haven't. While it is typically envisaged as a tool for managing a monorepo, it can be used as well for managing single projects in a repository.

Pants started at Twitter to handle their Scala monorepo, but was eventually spun off into its own thing, with a Pants v2 engine being a complete re-write from the ground up, focusing on more generalized use cases, rather than being an open-sourced version of a large SV company's build tools.

## What's the difference between this Python project and similar ones?

Unlike Poetry or Flit, Pants has very strong support for multiple build targets, and can easily manage multiple projects with a single repository. It's a general purpose build tool that could be integrated with multiple language environments. Unlike some of the other tools in its class (like Bazel or Please), Pants is very actively developed, and has a very active community. 

--

Anyone who agrees with this pull request could submit an *Approve* review to it.
